### PR TITLE
Add module hooks for Lumino

### DIFF
--- a/lumino/lumino.c
+++ b/lumino/lumino.c
@@ -259,15 +259,6 @@ bool process_record_lumino(uint16_t keycode, keyrecord_t* record) {
       }
       return false;
 
-    case QK_BOOT:
-      if (record->event.pressed) {
-        rgb_matrix_enable_noeeprom();
-        rgb_matrix_set_color_all(LUMINO_BOOT_COLOR);
-        rgb_matrix_update_pwm_buffers();
-        wait_ms(50);  // Wait briefly for PWM to update.
-      }
-      return true;
-
     default:
       if (awake_value > 0) {
         if (!awake || (anim_start_time && anim_end_value == 0)) {
@@ -280,3 +271,11 @@ bool process_record_lumino(uint16_t keycode, keyrecord_t* record) {
   }
 }
 
+bool shutdown_lumino(bool jump_to_bootloader) {
+  if (!shutdown_lumino_kb(jump_to_bootloader)) {
+    rgb_matrix_enable_noeeprom();
+    rgb_matrix_set_color_all(LUMINO_BOOT_COLOR);
+    rgb_matrix_update_pwm_buffers();
+  }
+  return true;
+}

--- a/lumino/lumino.c
+++ b/lumino/lumino.c
@@ -273,9 +273,11 @@ bool process_record_lumino(uint16_t keycode, keyrecord_t* record) {
 
 bool shutdown_lumino(bool jump_to_bootloader) {
   if (!shutdown_lumino_kb(jump_to_bootloader)) {
-    rgb_matrix_enable_noeeprom();
-    rgb_matrix_set_color_all(LUMINO_BOOT_COLOR);
-    rgb_matrix_update_pwm_buffers();
+    return false;
   }
+  rgb_matrix_enable_noeeprom();
+  rgb_matrix_set_color_all(LUMINO_BOOT_COLOR);
+  rgb_matrix_update_pwm_buffers();
+  
   return true;
 }

--- a/lumino/lumino.c
+++ b/lumino/lumino.c
@@ -232,6 +232,7 @@ void housekeeping_task_lumino(void) {
     anim_play(ANIM_SLEEP, 0);  // Go to sleep.
   }
 #endif  // USE_SLEEP_TIMER
+  houskeeping_task_lumino_kb();
 }
 
 void keyboard_post_init_lumino(void) {
@@ -240,9 +241,13 @@ void keyboard_post_init_lumino(void) {
     update_current_value(0);
     anim_play(ANIM_WAKE, awake_value);
   }
+  keyboard_post_init_lumino_kb();
 }
 
 bool process_record_lumino(uint16_t keycode, keyrecord_t* record) {
+  if (!process_record_lumino_kb(keycode, recored) {
+    return false;
+  }
 #ifdef USE_SLEEP_TIMER
   event_count = qadd8(event_count, 1);
 #endif  // USE_SLEEP_TIMER


### PR DESCRIPTION
While double checking, if you don't explicitly call these hooks, they don't get called.  
Ran into issues with this, as I have some custom code that needs updating.


Also, it may be best to return true on all of the keycodes, in `process_record_lumino`

Also, I've moved the code for `QK_BOOT`, to `shutdown_lumino` which anything reset function calls. This allows for software reset from other sources (such as a tap dance) to also trigger the behavior.  And no 50ms delay is needed here, since the function has a 250ms delay after kb/module hooks are called.