### PR TITLE
Allows supplementing default behavior using post_process_user_record(…

### DIFF
--- a/orbital_mouse/orbital_mouse.c
+++ b/orbital_mouse/orbital_mouse.c
@@ -372,7 +372,7 @@ bool process_record_orbital_mouse(uint16_t keycode, keyrecord_t* record) {
   state.wheel_x_dir = get_dir_from_held_keys(6);
   wake_orbital_mouse_task();
 
-  return false;
+  return true;
 }
 
 void housekeeping_task_orbital_mouse(void) {


### PR DESCRIPTION
Likely an accidental regression caused by adding support for holding OM_CS_U, et. al. ([8b8da23](https://github.com/getreuer/qmk-modules/commit/8b8da23733177cd838219d441a401c0ef89143b0))
