### PR TITLE
Implement super_leader_sequence_active() 

### DIFF
--- a/super_leader/super_leader.c
+++ b/super_leader/super_leader.c
@@ -296,6 +296,10 @@ void super_leader_add(uint16_t keycode) {
   }
 }
 
+bool super_leader_sequence_active(void) {
+  return leader.state == STATE_ACTIVE;
+}
+
 bool process_record_super_leader(uint16_t keycode, keyrecord_t* record) {
   if (leader.state == STATE_RECURSING || is_layer_key(keycode, record)) {
     return true;


### PR DESCRIPTION
Documentation declares a `super_leader_sequence_active()` function to check status of super_leader, as well as `bool super_leader_sequence_active(void)` being declared in `super_leader.h`. However, there is no function definition in `super_leader.c`. This adds that function. 

```
bool super_leader_sequence_active(void) {
  return leader.state == STATE_ACTIVE;
}
```

I wasn't sure if you'd prefer `== STATE_ACTIVE` or `!= STATE_OFF`, so I went with what made the most sense to me, considering the other states aren't really actively collecting leader sequence keys. I apologize if I've just missed something and you were handling this a different way.

Hope it helps!


Matthew Pardue